### PR TITLE
fixed global leak detected error

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function () {
 
   stream.destroy = function () {
     if(destroyed) return
-    destroyed = ended = true     
+    destroyed = this.ended = true
     buffer.length = 0
     this.emit('close')
   }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "test"
   },
   "devDependencies": {
+    "stream-tester": "0.0.2",
     "stream-spec": "~0.2.0"
   },
   "scripts": {


### PR DESCRIPTION
When using `pause-stream` in `mocha` test, it will come out `Error: global leak detected: ended`.

It caused by `pause-stream`.

And I also add the `stream-tester` to devDependencies.
