### PR TITLE
Using SPDX syntax for license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,7 @@
     "buffer"
   ],
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
-  "license": [
-    "MIT",
-    "Apache2"
-  ],
+  "license" : "(Apache-2.0 OR MIT)",
   "dependencies": {
     "through": "~2.3"
   }


### PR DESCRIPTION
Hi,
The spec for package.json recommends to use an SPDX expression in a string to express dual licensing (cf. https://docs.npmjs.com/files/package.json#license ). The array breaks some parsers.
Thanks, 
Camille